### PR TITLE
Add Docker Instructions and Update Workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git/
+doc/
+docker/
+\.*
+
+LICENSE
+*.md

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ colcon build
 ## Usage
 See the [documentation](doc/index.rst) for usage.
 
+## Docker
+A basic containerized workflow is provided to test this package in isolation.
+For more information refer to the [docker documentation](docker/RUNNING_IN_DOCKER.md).
+
 ## Future Work
 Here are several potential areas for future improvement:
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,27 +1,39 @@
 ARG ROS_DISTRO=humble
-FROM ros:$ROS_DISTRO
-ARG MUJOCO_VERSION=3.0.1
-ARG BRANCH=humble-devel
 
+FROM ros:${ROS_DISTRO}
+
+ARG MUJOCO_VERSION=3.2.7
+ARG CPU_ARCH=x86_64
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Configure base dependencies
 RUN apt-get update && apt-get upgrade -y
-RUN apt-get install -y python3-pip wget
-ENV SHELL /bin/bash
-
+RUN apt-get install -y python3-pip wget libglfw3-dev
 RUN pip3 install xacro
-# install mujoco
-ENV MUJOCO_VERSION $MUJOCO_VERSION
-RUN apt-get install -y libglfw3-dev
-RUN wget https://github.com/google-deepmind/mujoco/releases/download/$MUJOCO_VERSION/mujoco-$MUJOCO_VERSION-linux-x86_64.tar.gz
+
+# Configure and install MuJoCo
+ENV MUJOCO_VERSION=${MUJOCO_VERSION}
+ENV MUJOCO_DIR="/opt/mujoco/mujoco-${MUJOCO_VERSION}"
+RUN mkdir -p ${MUJOCO_DIR}
+
+RUN wget https://github.com/google-deepmind/mujoco/releases/download/${MUJOCO_VERSION}/mujoco-${MUJOCO_VERSION}-linux-${CPU_ARCH}.tar.gz
 RUN mkdir -p /home/mujoco
-RUN tar -xzf mujoco-3.0.1-linux-x86_64.tar.gz -C "/home/mujoco"
+RUN tar -xzf "mujoco-${MUJOCO_VERSION}-linux-${CPU_ARCH}.tar.gz" -C $(dirname "${MUJOCO_DIR}")
 
-RUN mkdir -p /home/ros2_ws/src \
-    && cd /home/ros2_ws/src/ \
-    && git clone -b $BRANCH https://github.com/sangteak601/mujoco_ros2_control.git \
-    && rosdep fix-permissions && rosdep update \
-    && rosdep install rosdep install --from-paths ./ --ignore-src -y
+# Install existing src and dependencies
+ENV ROS_WS="/home/ros2_ws/"
+RUN mkdir -p ${ROS_WS}/src
+WORKDIR ${ROS_WS}
+COPY . src/
 
-RUN echo 'export MUJOCO_DIR=/home/mujoco/mujoco-$MUJOCO_VERSION' >> ~/.bashrc
-RUN echo 'source /opt/ros/humble/setup.bash' >> ~/.bashrc
+# Install ROS dependencies
+RUN rosdep update && rosdep install --from-paths src/ --ignore-src -y
+
+# Compile
+RUN . /opt/ros/${ROS_DISTRO}/setup.bash && \
+    colcon build --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTING=ON
+
+RUN echo 'source ${ROS_WS}/install/setup.bash' >> ~/.bashrc
 
 CMD ["/bin/bash"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,7 +32,7 @@ RUN rosdep update && rosdep install --from-paths src/ --ignore-src -y
 
 # Compile
 RUN . /opt/ros/${ROS_DISTRO}/setup.bash && \
-    colcon build --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTING=ON
+    colcon build --cmake-args -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON
 
 RUN echo 'source ${ROS_WS}/install/setup.bash' >> ~/.bashrc
 

--- a/docker/RUNNING_IN_DOCKER.md
+++ b/docker/RUNNING_IN_DOCKER.md
@@ -1,0 +1,34 @@
+# Running in Docker
+
+We have provided a basic container to run the provided demonstrations in isolation.
+The [Dockerfile](Dockerfile) handles installing dependencies, MuJoCo, and building the packages in this environment.
+
+To build, clone the repo and run [the build script](./build.sh), e.g. from the repo root:
+
+```bash
+./docker/build.sh
+```
+
+This will create a local image (generally `mujoco_ros2:latest`):
+
+```bash
+$ docker image ls
+REPOSITORY                       TAG       IMAGE ID       CREATED             SIZE
+mujoco_ros2                      latest    37874e0d663a   6 minutes ago       1.52GB
+```
+
+To run the container use [the run script](./run.sh), which will drop you into the pre-compiled workspace.
+From here launch any of the demo launch scripts:
+
+```bash
+$ ./docker/run.sh
+root@ubuntu-linux:/home/ros2_ws# ros2 launch mujoco_ros2_control_demos cart_example_position.launch.py
+...
+```
+
+The run script includes the required variables to enable a Ubuntu host to pass through varibles to access the display.
+However, it may be required to give permissions prior to launching the container with:
+
+```bash
+xhost +local:docker
+```

--- a/docker/RUNNING_IN_DOCKER.md
+++ b/docker/RUNNING_IN_DOCKER.md
@@ -17,7 +17,7 @@ REPOSITORY                       TAG       IMAGE ID       CREATED             SI
 mujoco_ros2                      latest    37874e0d663a   6 minutes ago       1.52GB
 ```
 
-To run the container use [the run script](./run.sh), which will drop you into the pre-compiled workspace.
+To launch the container use [the run script](./run.sh), which will drop you into the pre-compiled workspace.
 From here launch any of the demo launch scripts:
 
 ```bash
@@ -30,5 +30,13 @@ The run script includes the required variables to enable a Ubuntu host to pass t
 However, it may be required to give permissions prior to launching the container with:
 
 ```bash
+# Run on host prior to launching the container
 xhost +local:docker
+```
+
+To test the MuJoCo install and rendering:
+
+```bash
+$ ./docker/run.sh
+root@ubuntu-linux:/home/ros2_ws# ${MUJOCO_DIR}/bin/simulate ${MUJOCO_DIR}/model/humanoid/humanoid.xml
 ```

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Get the directory of this script (where the Dockerfile is located)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Default values, modify as needed
+IMAGE_NAME="mujoco_ros2"
+ROS_DISTRO="humble"
+MUJOCO_VERSION="3.2.7"
+TAG="latest"
+
+# Grab CPU architecture to support ARM machines
+ARCH="$(uname -m)"
+CPU_ARCH="x86_64"
+if [[ "$ARCH" == "aarch64" || "$ARCH" == "arm64" ]]; then
+    CPU_ARCH="aarch64"
+fi
+
+# Build the Docker image, context from the root directory
+docker build --build-arg ROS_DISTRO="${ROS_DISTRO}" \
+             --build-arg MUJOCO_VERSION="${MUJOCO_VERSION}" \
+             --build-arg CPU_ARCH="${CPU_ARCH}" \
+             -f "${SCRIPT_DIR}/Dockerfile" \
+             -t "${IMAGE_NAME}:${TAG}" "${SCRIPT_DIR}/.."

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Default values, modify as needed, depending on build
+CONTAINER_NAME="mujoco_ros2_ws"
+IMAGE_NAME="mujoco_ros2"
+TAG="latest"
+
+docker run --rm \
+           -it \
+           --network host \
+           -e DISPLAY \
+           --name ${CONTAINER_NAME} \
+           ${IMAGE_NAME}:${TAG}

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -9,5 +9,7 @@ docker run --rm \
            -it \
            --network host \
            -e DISPLAY \
+           -e QT_X11_NO_MITSHM=1 \
+           -v /tmp/.X11-unix:/tmp/.X11-unix:ro \
            --name ${CONTAINER_NAME} \
            ${IMAGE_NAME}:${TAG}


### PR DESCRIPTION
Addresses https://github.com/moveit/mujoco_ros2_control/issues/15

Added instructions, a build script, and run script to the docker folder to support running this in a container as is.

Also made some slight modifications to the Dockerfile to avoid having to reclone the repo, as well as to support ARM CPUs. While I was at it, also bumped the default install version to 3.2.7.