### PR TITLE
Address crashes on demo starts for non-debug builds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,7 +32,7 @@ RUN rosdep update && rosdep install --from-paths src/ --ignore-src -y
 
 # Compile
 RUN . /opt/ros/${ROS_DISTRO}/setup.bash && \
-    colcon build --cmake-args -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON
+    colcon build --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTING=ON
 
 RUN echo 'source ${ROS_WS}/install/setup.bash' >> ~/.bashrc
 

--- a/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_system.hpp
+++ b/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_system.hpp
@@ -92,12 +92,12 @@ private:
     return (v < lo) ? lo : (hi < v) ? hi : v;
   }
 
+  std::vector<hardware_interface::StateInterface> state_interfaces_;
+  std::vector<hardware_interface::CommandInterface> command_interfaces_;
+
   std::vector<JointState> joint_states_;
   std::vector<FTSensorData> ft_sensor_data_;
   std::vector<IMUSensorData> imu_sensor_data_;
-
-  std::unordered_map<std::string, hardware_interface::ComponentInfo> joint_hw_info_;
-  std::unordered_map<std::string, hardware_interface::ComponentInfo> sensors_hw_info_;
 
   mjModel* mj_model_;
   mjData* mj_data_;

--- a/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_system.hpp
+++ b/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_system.hpp
@@ -92,12 +92,12 @@ private:
     return (v < lo) ? lo : (hi < v) ? hi : v;
   }
 
-  std::vector<hardware_interface::StateInterface> state_interfaces_;
-  std::vector<hardware_interface::CommandInterface> command_interfaces_;
-
   std::vector<JointState> joint_states_;
   std::vector<FTSensorData> ft_sensor_data_;
   std::vector<IMUSensorData> imu_sensor_data_;
+
+  std::unordered_map<std::string, hardware_interface::ComponentInfo> joint_hw_info_;
+  std::unordered_map<std::string, hardware_interface::ComponentInfo> sensors_hw_info_;
 
   mjModel* mj_model_;
   mjData* mj_data_;

--- a/mujoco_ros2_control/src/mujoco_ros2_control.cpp
+++ b/mujoco_ros2_control/src/mujoco_ros2_control.cpp
@@ -97,9 +97,9 @@ void MujocoRos2Control::init()
   // Create the controller manager
   RCLCPP_INFO(logger_, "Loading controller_manager");
   cm_executor_ = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
-  controller_manager_.reset(new controller_manager::ControllerManager(
+  controller_manager_ = std::make_shared<controller_manager::ControllerManager>(
       std::move(resource_manager), cm_executor_,
-      "controller_manager", node_->get_namespace()));
+      "controller_manager", node_->get_namespace());
 
   cm_executor_->add_node(controller_manager_);
 

--- a/mujoco_ros2_control/src/mujoco_system.cpp
+++ b/mujoco_ros2_control/src/mujoco_system.cpp
@@ -129,6 +129,8 @@ hardware_interface::return_type MujocoSystem::read(const rclcpp::Time & time, co
     data.torque.data.y() = -mj_data_->sensordata[data.torque.mj_sensor_index + 1];
     data.torque.data.z() = -mj_data_->sensordata[data.torque.mj_sensor_index + 2];
   }
+
+  return hardware_interface::return_type::OK;
 }
 
 hardware_interface::return_type MujocoSystem::write(const rclcpp::Time & time, const rclcpp::Duration & period)
@@ -184,6 +186,8 @@ hardware_interface::return_type MujocoSystem::write(const rclcpp::Time & time, c
       mj_data_->qfrc_applied[joint_state.mj_vel_adr] = clamp(joint_state.effort_command, min_eff, max_eff);
     }
   }
+
+  return hardware_interface::return_type::OK;
 }
 
 bool MujocoSystem::init_sim(rclcpp::Node::SharedPtr& node, mjModel* mujoco_model, mjData *mujoco_data,

--- a/mujoco_ros2_control/src/mujoco_system.cpp
+++ b/mujoco_ros2_control/src/mujoco_system.cpp
@@ -102,7 +102,7 @@ std::vector<hardware_interface::CommandInterface> MujocoSystem::export_command_i
   return new_command_interfaces;
 }
 
-hardware_interface::return_type MujocoSystem::read(const rclcpp::Time & time, const rclcpp::Duration & period)
+hardware_interface::return_type MujocoSystem::read(const rclcpp::Time & /* time */, const rclcpp::Duration & /* period */)
 {
   // Joint states
   for (auto& joint_state : joint_states_)
@@ -113,10 +113,10 @@ hardware_interface::return_type MujocoSystem::read(const rclcpp::Time & time, co
   }
 
   // IMU Sensor data
-  for (auto& data : imu_sensor_data_)
-  {
-    // TODO
-  }
+  // TODO: For now all sensors are assumed to be FTS
+  // for (auto& data : imu_sensor_data_)
+  // {
+  // }
 
   // FT Sensor data
   for (auto& data : ft_sensor_data_)
@@ -133,7 +133,7 @@ hardware_interface::return_type MujocoSystem::read(const rclcpp::Time & time, co
   return hardware_interface::return_type::OK;
 }
 
-hardware_interface::return_type MujocoSystem::write(const rclcpp::Time & time, const rclcpp::Duration & period)
+hardware_interface::return_type MujocoSystem::write(const rclcpp::Time & /* time */, const rclcpp::Duration & period)
 {
   // update mimic joint
   for (auto& joint_state : joint_states_)
@@ -361,7 +361,7 @@ void MujocoSystem::register_joints(const urdf::Model& urdf_model, const hardware
   }
 }
 
-void MujocoSystem::register_sensors(const urdf::Model& urdf_model, const hardware_interface::HardwareInfo & hardware_info)
+void MujocoSystem::register_sensors(const urdf::Model& /* urdf_model */, const hardware_interface::HardwareInfo & hardware_info)
 {
   // TODO: for now, assuming all sensors are ft_sensor
   ft_sensor_data_.resize(hardware_info.sensors.size());

--- a/mujoco_ros2_control/src/mujoco_system.cpp
+++ b/mujoco_ros2_control/src/mujoco_system.cpp
@@ -8,12 +8,98 @@ MujocoSystem::MujocoSystem() : logger_(rclcpp::get_logger(""))
 
 std::vector<hardware_interface::StateInterface> MujocoSystem::export_state_interfaces()
 {
-  return std::move(state_interfaces_);
+  std::vector<hardware_interface::StateInterface> new_state_interfaces;
+
+  for (auto& joint : joint_states_)
+  {
+    // Add state interfaces for joint hardware.
+    if (auto it = joint_hw_info_.find(joint.name); it != joint_hw_info_.end())
+    {
+      for (const auto& state_if : it->second.state_interfaces)
+      {
+        if (state_if.name == hardware_interface::HW_IF_POSITION)
+        {
+          new_state_interfaces.emplace_back(joint.name, hardware_interface::HW_IF_POSITION, &joint.position);
+        }
+        else if (state_if.name == hardware_interface::HW_IF_VELOCITY)
+        {
+          new_state_interfaces.emplace_back(joint.name, hardware_interface::HW_IF_VELOCITY, &joint.velocity);
+        }
+        else if (state_if.name == hardware_interface::HW_IF_EFFORT)
+        {
+          new_state_interfaces.emplace_back(joint.name, hardware_interface::HW_IF_EFFORT, &joint.effort);
+        }
+      }
+    }
+  }
+
+  // Add state interfaces for sensors
+  for (auto& sensor : ft_sensor_data_)
+  {
+    if (auto it = sensors_hw_info_.find(sensor.name); it != sensors_hw_info_.end())
+    {
+      for (const auto& state_if : it->second.state_interfaces)
+      {
+        if (state_if.name == "force.x")
+        {
+          new_state_interfaces.emplace_back(sensor.name, state_if.name, &sensor.force.data.x());
+        }
+        else if (state_if.name == "force.y")
+        {
+          new_state_interfaces.emplace_back(sensor.name, state_if.name, &sensor.force.data.y());
+        }
+        else if (state_if.name == "force.z")
+        {
+          new_state_interfaces.emplace_back(sensor.name, state_if.name, &sensor.force.data.z());
+        }
+        else if (state_if.name == "torque.x")
+        {
+          new_state_interfaces.emplace_back(sensor.name, state_if.name, &sensor.torque.data.x());
+        }
+        else if (state_if.name == "torque.y")
+        {
+          new_state_interfaces.emplace_back(sensor.name, state_if.name, &sensor.torque.data.y());
+        }
+        else if (state_if.name == "torque.z")
+        {
+          new_state_interfaces.emplace_back(sensor.name, state_if.name, &sensor.torque.data.z());
+        }
+      }
+    }
+  }
+
+  return new_state_interfaces;
 }
 
 std::vector<hardware_interface::CommandInterface> MujocoSystem::export_command_interfaces()
 {
-  return std::move(command_interfaces_);
+  std::vector<hardware_interface::CommandInterface> new_command_interfaces;
+
+  // Joint command interfaces
+  for (auto& joint : joint_states_)
+  {
+    // Add command interfaces for joint hardware.
+    if (auto it = joint_hw_info_.find(joint.name); it != joint_hw_info_.end())
+    {
+      for (const auto& command_if : it->second.command_interfaces)
+      {
+        if (command_if.name.find(hardware_interface::HW_IF_POSITION) != std::string::npos)
+        {
+          new_command_interfaces.emplace_back(joint.name, hardware_interface::HW_IF_POSITION, &joint.position_command);
+        }
+        else if (command_if.name.find(hardware_interface::HW_IF_VELOCITY) != std::string::npos)
+        {
+          new_command_interfaces.emplace_back(joint.name, hardware_interface::HW_IF_VELOCITY, &joint.velocity_command);
+        }
+        else if (command_if.name == hardware_interface::HW_IF_EFFORT)
+        {
+          new_command_interfaces.emplace_back(joint.name, hardware_interface::HW_IF_EFFORT, &joint.effort_command);
+        }
+      }
+    }
+  }
+
+  return new_command_interfaces;
 }
 
 hardware_interface::return_type MujocoSystem::read(const rclcpp::Time & time, const rclcpp::Duration & period)
@@ -110,7 +196,7 @@ bool MujocoSystem::init_sim(rclcpp::Node::SharedPtr& node, mjModel* mujoco_model
   logger_ = rclcpp::get_logger(node_->get_name() + std::string("mujoco_system"));
 
   register_joints(urdf_model, hardware_info);
-  register_sensors(urdf_model,hardware_info);
+  register_sensors(urdf_model, hardware_info);
 
   set_initial_pose();
   return true;
@@ -129,6 +215,9 @@ void MujocoSystem::register_joints(const urdf::Model& urdf_model, const hardware
       RCLCPP_ERROR_STREAM(logger_, "Failed to find joint in mujoco model, joint name: " << joint.name);
       continue;
     }
+
+    // Add to the joint hw information map
+    joint_hw_info_.insert(std::make_pair(joint.name, joint));
 
     // save information in joint_states_ variable
     JointState joint_state;
@@ -182,22 +271,19 @@ void MujocoSystem::register_joints(const urdf::Model& urdf_model, const hardware
       }
     };
 
-    // state interfaces
+    // Set initial values
     for (const auto& state_if : joint.state_interfaces)
     {
       if (state_if.name == hardware_interface::HW_IF_POSITION)
       {
-        state_interfaces_.emplace_back(joint.name, hardware_interface::HW_IF_POSITION, &last_joint_state.position);
         last_joint_state.position = get_initial_value(state_if);
       }
       else if (state_if.name == hardware_interface::HW_IF_VELOCITY)
       {
-        state_interfaces_.emplace_back(joint.name, hardware_interface::HW_IF_VELOCITY, &last_joint_state.velocity);
         last_joint_state.velocity = get_initial_value(state_if);
       }
       else if (state_if.name == hardware_interface::HW_IF_EFFORT)
       {
-        state_interfaces_.emplace_back(joint.name, hardware_interface::HW_IF_EFFORT, &last_joint_state.effort);
         last_joint_state.effort = get_initial_value(state_if);
       }
     }
@@ -234,7 +320,6 @@ void MujocoSystem::register_joints(const urdf::Model& urdf_model, const hardware
     {
       if (command_if.name.find(hardware_interface::HW_IF_POSITION) != std::string::npos)
       {
-        command_interfaces_.emplace_back(joint.name, hardware_interface::HW_IF_POSITION, &last_joint_state.position_command);
         last_joint_state.is_position_control_enabled = true;
         last_joint_state.position_command = last_joint_state.position;
         // TODO: These are not used at all. Potentially can be removed.
@@ -243,7 +328,6 @@ void MujocoSystem::register_joints(const urdf::Model& urdf_model, const hardware
       }
       else if (command_if.name.find(hardware_interface::HW_IF_VELOCITY) != std::string::npos)
       {
-        command_interfaces_.emplace_back(joint.name, hardware_interface::HW_IF_VELOCITY, &last_joint_state.velocity_command);
         last_joint_state.is_velocity_control_enabled = true;
         last_joint_state.velocity_command = last_joint_state.velocity;
         // TODO: These are not used at all. Potentially can be removed.
@@ -252,7 +336,6 @@ void MujocoSystem::register_joints(const urdf::Model& urdf_model, const hardware
       }
       else if (command_if.name == hardware_interface::HW_IF_EFFORT)
       {
-        command_interfaces_.emplace_back(joint.name, hardware_interface::HW_IF_EFFORT, &last_joint_state.effort_command);
         last_joint_state.is_effort_control_enabled = true;
         last_joint_state.effort_command = last_joint_state.effort;
         last_joint_state.min_effort_command = get_min_value(command_if);
@@ -283,6 +366,9 @@ void MujocoSystem::register_sensors(const urdf::Model& urdf_model, const hardwar
   {
     auto sensor = hardware_info.sensors.at(sensor_index);
 
+    // Add to the sensor hw information map
+    sensors_hw_info_.insert(std::make_pair(sensor.name, sensor));
+
     FTSensorData sensor_data;
     sensor_data.name = sensor.name;
     sensor_data.force.name = sensor.name + "_force";
@@ -301,35 +387,6 @@ void MujocoSystem::register_sensors(const urdf::Model& urdf_model, const hardwar
     sensor_data.torque.mj_sensor_index = mj_model_->sensor_adr[torque_sensor_id];
 
     ft_sensor_data_.at(sensor_index) = sensor_data;
-    auto& last_sensor_data = ft_sensor_data_.at(sensor_index);
-
-    for (const auto& state_if : sensor.state_interfaces)
-    {
-      if (state_if.name == "force.x")
-      {
-        state_interfaces_.emplace_back(sensor.name, state_if.name, &last_sensor_data.force.data.x());
-      }
-      else if (state_if.name == "force.y")
-      {
-        state_interfaces_.emplace_back(sensor.name, state_if.name, &last_sensor_data.force.data.y());
-      }
-      else if (state_if.name == "force.z")
-      {
-        state_interfaces_.emplace_back(sensor.name, state_if.name, &last_sensor_data.force.data.z());
-      }
-      else if (state_if.name == "torque.x")
-      {
-        state_interfaces_.emplace_back(sensor.name, state_if.name, &last_sensor_data.torque.data.x());
-      }
-      else if (state_if.name == "torque.y")
-      {
-        state_interfaces_.emplace_back(sensor.name, state_if.name, &last_sensor_data.torque.data.y());
-      }
-      else if (state_if.name == "torque.z")
-      {
-        state_interfaces_.emplace_back(sensor.name, state_if.name, &last_sensor_data.torque.data.z());
-      }
-    }
   }
 }
 


### PR DESCRIPTION
Resolves https://github.com/moveit/mujoco_ros2_control/issues/22 (I think).

I think there were two issues happening with the `MujocoSystem` class. I couldn't pinpoint exactly what was happening (the very definition of undefined behavior!) but these changes seem to have resolved the segfaults on my system. To summarize:

* Transferring ownership of the state and command interfaces out of the `MujocoSystem` object. I modified the export functions to create new vectors on demand, rather than allocating that memory in the init functions and then transferring. I just added maps to store the hardware information from the init functions.
* Returning nothing (void) from the read and write functions. We need to return valid responses to the ros2 control interface or odd things can happen.

Those two changes together allow me to build and run without issues after resetting the default to `RelWithDebInfo` rather than `Debug`. While I was at it I also addressed a few other compiler issues and warnings.

Let me know if this works for you.