### PR TITLE
Adding basic RGB-D camera support

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -33,17 +33,26 @@ Use ``mujoco_ros2_control/MujocoSystem`` for plugin
     </joint>
   </ros2_control>
 
-Convert URDF model to xml
+Convert URDF model to XML
 --------------------------
-You need to convert the URDF model to a MJCF XML file.
+URDF models must be converted to `MJCF XML <https://mujoco.readthedocs.io/en/latest/modeling.html>`_ files.
 Make sure to use the same name for the link and joint, which are mapped to the body and joint in Mujoco.
-You need to specify <limit> which is mapped to ``range`` in MJCF. For now, there is no way to specify velocity or acceleration limit.
+You need to specify <limit> which is mapped to ``range`` in MJCF.
+For now, there is no way to specify velocity or acceleration limit.
 
-For force torque sensor, you need to map the sensor to a force sensor and a torque sensor in MJCF since there is no combined force torque sensor in MuJoCo.
-The name of each sensor should be ``sensor_name`` + ``_force`` and ``sensor_name`` + ``_torque``.
-For example, if you have a force torque sensor called ``my_sensor``, you need to create ``my_sensor_force`` and ``my_sensor_torque`` in MJCF.
+For force torque sensors, there is no combined force torque sensor in MuJoCo.
+Therefore in ROS, a single force torque sensor must be mapped to both a force sensor and a torque sensor in MJCF.
+The name of each sensor must be ``sensor_name`` + ``_force`` and ``sensor_name`` + ``_torque``.
+For example, the mapped names for a ROS force torque sensor ``my_sensor`` would be ``my_sensor_force`` and ``my_sensor_torque`` in MJCF.
 
-Check ``mujoco_ros2_control_demos/mujoco_models`` for examples.
+The drivers additionally support simulated RGB-D cameras for publishing simulated color images and depth maps.
+Cameras must be given a name and be attached to a joint called ``<name>_optical_frame``.
+The camera_info, color, and depth images will be published to topics called ``<name>/camera_info``,
+``<name>/color``, and ``<name>/depth``, repectively.
+Also note that MuJuCo's conventions for cameras are different than ROS's, and which must be accounted for.
+An overview is available through the "camera" demo.
+
+For additional information refer to the ``mujoco_ros2_control_demos/mujoco_models`` for examples.
 
 Specify the location of Mujoco models and the controller configuration file
 ----------------------------------------------------------------------------

--- a/mujoco_ros2_control/CMakeLists.txt
+++ b/mujoco_ros2_control/CMakeLists.txt
@@ -71,7 +71,12 @@ install(TARGETS
 )
 
 # TODO: make it simple
-add_executable(mujoco_ros2_control src/mujoco_ros2_control_node.cpp src/mujoco_rendering.cpp src/mujoco_ros2_control.cpp)
+add_executable(mujoco_ros2_control
+  src/mujoco_ros2_control_node.cpp
+  src/mujoco_rendering.cpp
+  src/mujoco_ros2_control.cpp
+  src/mujoco_cameras.cpp
+)
 ament_target_dependencies(mujoco_ros2_control ${THIS_PACKAGE_DEPENDS})
 target_link_libraries(mujoco_ros2_control ${MUJOCO_LIB} glfw)
 target_include_directories(mujoco_ros2_control

--- a/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_cameras.hpp
+++ b/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_cameras.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Sangtaek Lee
+// Copyright (c) 2025 Erik Holum
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_cameras.hpp
+++ b/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_cameras.hpp
@@ -18,8 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#ifndef MUJOCO_ROS2_CONTROL__MUJOCO_RENDERING_HPP_
-#define MUJOCO_ROS2_CONTROL__MUJOCO_RENDERING_HPP_
+#pragma once
 
 #include <string>
 #include <vector>
@@ -29,54 +28,59 @@
 #include "rclcpp/rclcpp.hpp"
 
 #include "rclcpp/node.hpp"
+#include "rclcpp/publisher.hpp"
+#include "sensor_msgs/msg/camera_info.hpp"
+#include "sensor_msgs/msg/image.hpp"
 
 namespace mujoco_ros2_control
 {
 
-class MujocoRendering
+struct CameraData
+{
+  mjvCamera mjv_cam;
+  mjrRect viewport;
+
+  std::string name;
+  std::string frame_name;
+  uint32_t width;
+  uint32_t height;
+
+  std::vector<uint8_t> image_buffer;
+  std::vector<float> depth_buffer;
+  std::vector<float> depth_buffer_flipped;
+
+  sensor_msgs::msg::Image image;
+  sensor_msgs::msg::Image depth_image;
+  sensor_msgs::msg::CameraInfo camera_info;
+
+  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr image_pub;
+  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr depth_image_pub;
+  rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr camera_info_pub;
+};
+
+class MujocoCameras
 {
 public:
-  MujocoRendering(const MujocoRendering &obj) = delete;
-  void operator=(const MujocoRendering &) = delete;
+  MujocoCameras();
 
-  static MujocoRendering *get_instance();
-  void init(mjModel *mujoco_model, mjData *mujoco_data);
-  bool is_close_flag_raised();
-  void update();
+  void init(rclcpp::Node::SharedPtr &node, mjModel *mujoco_model, mjData *mujoco_data);
+  void update_cameras();
   void close();
 
 private:
-  MujocoRendering();
-  static void keyboard_callback(GLFWwindow *window, int key, int scancode, int act, int mods);
-  static void mouse_button_callback(GLFWwindow *window, int button, int act, int mods);
-  static void mouse_move_callback(GLFWwindow *window, double xpos, double ypos);
-  static void scroll_callback(GLFWwindow *window, double xoffset, double yoffset);
+  void register_cameras();
 
-  void keyboard_callback_impl(GLFWwindow *window, int key, int scancode, int act, int mods);
-  void mouse_button_callback_impl(GLFWwindow *window, int button, int act, int mods);
-  void mouse_move_callback_impl(GLFWwindow *window, double xpos, double ypos);
-  void scroll_callback_impl(GLFWwindow *window, double xoffset, double yoffset);
-
-  static MujocoRendering *instance_;
+  rclcpp::Node::SharedPtr node_;
 
   mjModel *mj_model_;
   mjData *mj_data_;
 
-  // Window and primary camera for the simulation's viewer
-  GLFWwindow *window_;
-  mjvCamera mjv_cam_;
-
-  // Options for the rendering context and scene, all of these are hard coded to defaults.
+  // Rendering options for the cameras, currently hard coded to defaults
   mjvOption mjv_opt_;
   mjvScene mjv_scn_;
   mjrContext mjr_con_;
 
-  bool button_left_;
-  bool button_middle_;
-  bool button_right_;
-  double lastx_;
-  double lasty_;
+  // Additional user specified cameras
+  std::vector<CameraData> cameras_;
 };
 }  // namespace mujoco_ros2_control
-
-#endif  // MUJOCO_ROS2_CONTROL__MUJOCO_RENDERING_HPP_

--- a/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_cameras.hpp
+++ b/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_cameras.hpp
@@ -61,26 +61,24 @@ struct CameraData
 class MujocoCameras
 {
 public:
-  MujocoCameras();
+  explicit MujocoCameras(rclcpp::Node::SharedPtr &node);
 
-  void init(rclcpp::Node::SharedPtr &node, mjModel *mujoco_model, mjData *mujoco_data);
-  void update_cameras();
+  void init(mjModel *mujoco_model);
+  void update(mjModel *mujoco_model, mjData *mujoco_data);
   void close();
 
 private:
-  void register_cameras();
+  void register_cameras(const mjModel *mujoco_model);
 
   rclcpp::Node::SharedPtr node_;
-
-  mjModel *mj_model_;
-  mjData *mj_data_;
 
   // Rendering options for the cameras, currently hard coded to defaults
   mjvOption mjv_opt_;
   mjvScene mjv_scn_;
   mjrContext mjr_con_;
 
-  // Additional user specified cameras
+  // Containers for camera data and ROS constructs
   std::vector<CameraData> cameras_;
 };
+
 }  // namespace mujoco_ros2_control

--- a/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_rendering.hpp
+++ b/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_rendering.hpp
@@ -46,6 +46,8 @@ struct CameraData
   uint32_t width;
   uint32_t height;
 
+  std::vector<uint8_t> image_buffer;
+
   sensor_msgs::msg::Image image;
   sensor_msgs::msg::CameraInfo camera_info;
 

--- a/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_rendering.hpp
+++ b/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_rendering.hpp
@@ -67,7 +67,6 @@ public:
   void close();
 
 private:
-
   MujocoRendering();
   static void keyboard_callback(GLFWwindow *window, int key, int scancode, int act, int mods);
   static void mouse_button_callback(GLFWwindow *window, int button, int act, int mods);
@@ -81,14 +80,14 @@ private:
 
   void register_cameras();
 
-  static MujocoRendering* instance_;
+  static MujocoRendering *instance_;
   rclcpp::Node::SharedPtr node_;
 
-  mjModel* mj_model_;
-  mjData* mj_data_;
+  mjModel *mj_model_;
+  mjData *mj_data_;
 
   // Window and primary camera for the simulation's viewer
-  GLFWwindow* window_;
+  GLFWwindow *window_;
   mjvCamera mjv_cam_;
 
   // Options for the rendering context and scene, all of these are hard coded to defaults.

--- a/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_rendering.hpp
+++ b/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_rendering.hpp
@@ -47,11 +47,15 @@ struct CameraData
   uint32_t height;
 
   std::vector<uint8_t> image_buffer;
+  std::vector<float> depth_buffer;
+  std::vector<float> depth_buffer_flipped;
 
   sensor_msgs::msg::Image image;
+  sensor_msgs::msg::Image depth_image;
   sensor_msgs::msg::CameraInfo camera_info;
 
   rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr image_pub;
+  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr depth_image_pub;
   rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr camera_info_pub;
 };
 

--- a/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_rendering.hpp
+++ b/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_rendering.hpp
@@ -21,12 +21,38 @@
 #ifndef MUJOCO_ROS2_CONTROL__MUJOCO_RENDERING_HPP_
 #define MUJOCO_ROS2_CONTROL__MUJOCO_RENDERING_HPP_
 
+#include <string>
+#include <vector>
+
 #include "GLFW/glfw3.h"
 #include "mujoco/mujoco.h"
 #include "rclcpp/rclcpp.hpp"
 
+#include "rclcpp/node.hpp"
+#include "rclcpp/publisher.hpp"
+#include "sensor_msgs/msg/camera_info.hpp"
+#include "sensor_msgs/msg/image.hpp"
+
 namespace mujoco_ros2_control
 {
+
+struct CameraData
+{
+  mjvCamera mjv_cam;
+  mjrRect viewport;
+
+  std::string name;
+  std::string frame_name;
+  uint32_t width;
+  uint32_t height;
+
+  sensor_msgs::msg::Image image;
+  sensor_msgs::msg::CameraInfo camera_info;
+
+  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr image_pub;
+  rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr camera_info_pub;
+};
+
 class MujocoRendering
 {
 public:
@@ -37,29 +63,41 @@ public:
   void init(rclcpp::Node::SharedPtr &node, mjModel *mujoco_model, mjData *mujoco_data);
   bool is_close_flag_raised();
   void update();
+  void update_cameras();
   void close();
 
 private:
+
   MujocoRendering();
   static void keyboard_callback(GLFWwindow *window, int key, int scancode, int act, int mods);
   static void mouse_button_callback(GLFWwindow *window, int button, int act, int mods);
   static void mouse_move_callback(GLFWwindow *window, double xpos, double ypos);
   static void scroll_callback(GLFWwindow *window, double xoffset, double yoffset);
+
   void keyboard_callback_impl(GLFWwindow *window, int key, int scancode, int act, int mods);
   void mouse_button_callback_impl(GLFWwindow *window, int button, int act, int mods);
   void mouse_move_callback_impl(GLFWwindow *window, double xpos, double ypos);
   void scroll_callback_impl(GLFWwindow *window, double xoffset, double yoffset);
 
-  static MujocoRendering *instance_;
-  rclcpp::Node::SharedPtr node_;  // TODO(sangtaek): delete node and add logger
-  mjModel *mj_model_;
-  mjData *mj_data_;
+  void register_cameras();
+
+  static MujocoRendering* instance_;
+  rclcpp::Node::SharedPtr node_;
+
+  mjModel* mj_model_;
+  mjData* mj_data_;
+
+  // Window and primary camera for the simulation's viewer
+  GLFWwindow* window_;
   mjvCamera mjv_cam_;
+
+  // Options for the rendering context and scene, all of these are hard coded to defaults.
   mjvOption mjv_opt_;
   mjvScene mjv_scn_;
   mjrContext mjr_con_;
 
-  GLFWwindow *window_;
+  // Additional user specified cameras
+  std::vector<CameraData> cameras_;
 
   bool button_left_;
   bool button_middle_;

--- a/mujoco_ros2_control/src/mujoco_cameras.cpp
+++ b/mujoco_ros2_control/src/mujoco_cameras.cpp
@@ -98,6 +98,12 @@ void MujocoCameras::update(mjModel *mujoco_model, mjData *mujoco_data)
   }
 }
 
+void MujocoCameras::close()
+{
+  mjv_freeScene(&mjv_scn_);
+  mjr_freeContext(&mjr_con_);
+}
+
 void MujocoCameras::register_cameras(const mjModel *mujoco_model)
 {
   cameras_.resize(0);

--- a/mujoco_ros2_control/src/mujoco_cameras.cpp
+++ b/mujoco_ros2_control/src/mujoco_cameras.cpp
@@ -1,0 +1,180 @@
+// Copyright (c) 2025 Sangtaek Lee
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "mujoco_ros2_control/mujoco_cameras.hpp"
+
+#include "sensor_msgs/image_encodings.hpp"
+
+namespace mujoco_ros2_control
+{
+
+MujocoCameras::MujocoCameras() : mj_model_(nullptr), mj_data_(nullptr) {}
+
+void MujocoCameras::init(rclcpp::Node::SharedPtr &node, mjModel *mujoco_model, mjData *mujoco_data)
+{
+  node_ = node;
+  mj_model_ = mujoco_model;
+  mj_data_ = mujoco_data;
+
+  // initialize visualization data structures
+  mjv_defaultOption(&mjv_opt_);
+  mjv_defaultScene(&mjv_scn_);
+  mjr_defaultContext(&mjr_con_);
+
+  // create scene and context
+  mjv_makeScene(mj_model_, &mjv_scn_, 2000);
+  mjr_makeContext(mj_model_, &mjr_con_, mjFONTSCALE_150);
+
+  // Add user cameras
+  register_cameras();
+
+  // This might cause tearing, but having RViz and the renderer both open can
+  // wreak havoc on the rendering process.
+  glfwSwapInterval(0);
+}
+
+void MujocoCameras::update_cameras()
+{
+  // Rendering is done offscreen
+  mjr_setBuffer(mjFB_OFFSCREEN, &mjr_con_);
+
+  for (auto &camera : cameras_)
+  {
+    // Render simple RGB data for all cameras
+    mjv_updateScene(mj_model_, mj_data_, &mjv_opt_, NULL, &camera.mjv_cam, mjCAT_ALL, &mjv_scn_);
+    mjr_render(camera.viewport, &mjv_scn_, &mjr_con_);
+
+    // Copy image into relevant buffers
+    mjr_readPixels(
+      camera.image_buffer.data(), camera.depth_buffer.data(), camera.viewport, &mjr_con_);
+
+    // Fix non-linear projections in the depth image and flip the data.
+    // https://github.com/google-deepmind/mujoco/blob/3.2.7/python/mujoco/renderer.py#L190
+    float near = static_cast<float>(mj_model_->vis.map.znear * mj_model_->stat.extent);
+    float far = static_cast<float>(mj_model_->vis.map.zfar * mj_model_->stat.extent);
+    for (uint32_t h = 0; h < camera.height; h++)
+    {
+      for (uint32_t w = 0; w < camera.width; w++)
+      {
+        auto idx = h * camera.width + w;
+        auto idx_flipped = (camera.height - 1 - h) * camera.width + w;
+        camera.depth_buffer[idx] = near / (1.0f - camera.depth_buffer[idx] * (1.0f - near / far));
+        camera.depth_buffer_flipped[idx_flipped] = camera.depth_buffer[idx];
+      }
+    }
+    // Copy flipped data into the depth image message, floats -> unsigned chars
+    std::memcpy(
+      &camera.depth_image.data[0], camera.depth_buffer_flipped.data(),
+      camera.depth_image.data.size());
+
+    // OpenGL's coordinate system's origin is in the bottom left, so we invert the images row-by-row
+    auto row_size = camera.width * 3;
+    for (uint32_t h = 0; h < camera.height; h++)
+    {
+      auto src_idx = h * row_size;
+      auto dest_idx = (camera.height - 1 - h) * row_size;
+      std::memcpy(&camera.image.data[dest_idx], &camera.image_buffer[src_idx], row_size);
+    }
+
+    // Publish images and camera info
+    auto time = node_->now();
+    camera.image.header.stamp = time;
+    camera.depth_image.header.stamp = time;
+    camera.camera_info.header.stamp = time;
+
+    camera.image_pub->publish(camera.image);
+    camera.depth_image_pub->publish(camera.depth_image);
+    camera.camera_info_pub->publish(camera.camera_info);
+  }
+}
+
+void MujocoCameras::register_cameras()
+{
+  cameras_.resize(0);
+  for (auto i = 0; i < mj_model_->ncam; ++i)
+  {
+    const char *cam_name = mj_model_->names + mj_model_->name_camadr[i];
+    const int *cam_resolution = mj_model_->cam_resolution + 2 * i;
+    const mjtNum cam_fovy = mj_model_->cam_fovy[i];
+
+    // Construct CameraData wrapper and set defaults
+    CameraData camera;
+    camera.name = cam_name;
+    camera.mjv_cam.type = mjCAMERA_FIXED;
+    camera.mjv_cam.fixedcamid = i;
+    camera.width = static_cast<uint32_t>(cam_resolution[0]);
+    camera.height = static_cast<uint32_t>(cam_resolution[1]);
+    camera.viewport = {0, 0, cam_resolution[0], cam_resolution[1]};
+
+    // TODO(eholum): Ensure that the camera is attached to the expected pose.
+    // For now assume that's the case.
+    camera.frame_name = camera.name + "_optical_frame";
+
+    // Configure publishers
+    camera.image_pub = node_->create_publisher<sensor_msgs::msg::Image>(camera.name + "/color", 1);
+    camera.depth_image_pub =
+      node_->create_publisher<sensor_msgs::msg::Image>(camera.name + "/depth", 1);
+    camera.camera_info_pub =
+      node_->create_publisher<sensor_msgs::msg::CameraInfo>(camera.name + "/camera_info", 1);
+
+    // Setup contaienrs for color image data
+    camera.image.header.frame_id = camera.frame_name;
+
+    const auto image_size = camera.width * camera.height * 3;
+    camera.image_buffer.resize(image_size);
+    camera.image.data.resize(image_size);
+    camera.image.width = camera.width;
+    camera.image.height = camera.height;
+    camera.image.step = camera.width * 3;
+    camera.image.encoding = sensor_msgs::image_encodings::RGB8;
+
+    // Depth image data
+    camera.depth_image.header.frame_id = camera.frame_name;
+    camera.depth_buffer.resize(camera.width * camera.height);
+    camera.depth_buffer_flipped.resize(camera.width * camera.height);
+    camera.depth_image.data.resize(camera.width * camera.height * sizeof(float));
+    camera.depth_image.width = camera.width;
+    camera.depth_image.height = camera.height;
+    camera.depth_image.step = camera.width * sizeof(float);
+    camera.depth_image.encoding = sensor_msgs::image_encodings::TYPE_32FC1;
+
+    // Camera info
+    camera.camera_info.header.frame_id = camera.frame_name;
+    camera.camera_info.width = camera.width;
+    camera.camera_info.height = camera.height;
+    camera.camera_info.distortion_model = "plumb_bob";
+    camera.camera_info.k.fill(0.0);
+    camera.camera_info.r.fill(0.0);
+    camera.camera_info.p.fill(0.0);
+    camera.camera_info.d.resize(5, 0.0);
+
+    double focal_scaling = (1.0 / std::tan((cam_fovy * M_PI / 180.0) / 2.0)) * camera.height / 2.0;
+    camera.camera_info.k[0] = camera.camera_info.p[0] = focal_scaling;
+    camera.camera_info.k[2] = camera.camera_info.p[2] = static_cast<double>(camera.width) / 2.0;
+    camera.camera_info.k[4] = camera.camera_info.p[5] = focal_scaling;
+    camera.camera_info.k[5] = camera.camera_info.p[6] = static_cast<double>(camera.height) / 2.0;
+    camera.camera_info.k[8] = camera.camera_info.p[10] = 1.0;
+
+    // Add to list of cameras
+    cameras_.push_back(camera);
+  }
+}
+
+}  // namespace mujoco_ros2_control

--- a/mujoco_ros2_control/src/mujoco_cameras.cpp
+++ b/mujoco_ros2_control/src/mujoco_cameras.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Sangtaek Lee
+// Copyright (c) 2025 Erik Holum
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/mujoco_ros2_control/src/mujoco_rendering.cpp
+++ b/mujoco_ros2_control/src/mujoco_rendering.cpp
@@ -47,18 +47,10 @@ MujocoRendering::MujocoRendering()
 {
 }
 
-void MujocoRendering::init(
-  rclcpp::Node::SharedPtr &node, mjModel *mujoco_model, mjData *mujoco_data)
+void MujocoRendering::init(mjModel *mujoco_model, mjData *mujoco_data)
 {
-  node_ = node;
   mj_model_ = mujoco_model;
   mj_data_ = mujoco_data;
-
-  // init GLFW
-  if (!glfwInit())
-  {
-    mju_error("Could not initialize GLFW");
-  }
 
   // create window, make OpenGL context current, request v-sync
   glfwWindowHint(GLFW_VISIBLE, GLFW_TRUE);
@@ -84,9 +76,6 @@ void MujocoRendering::init(
   glfwSetCursorPosCallback(window_, &MujocoRendering::mouse_move_callback);
   glfwSetMouseButtonCallback(window_, &MujocoRendering::mouse_button_callback);
   glfwSetScrollCallback(window_, &MujocoRendering::scroll_callback);
-
-  // Add user cameras
-  register_cameras();
 
   // This might cause tearing, but having RViz and the renderer both open can
   // wreak havoc on the rendering process.
@@ -114,61 +103,6 @@ void MujocoRendering::update()
 
   // process pending GUI events, call GLFW callbacks
   glfwPollEvents();
-}
-
-void MujocoRendering::update_cameras()
-{
-  // Rendering is done offscreen
-  mjr_setBuffer(mjFB_OFFSCREEN, &mjr_con_);
-
-  for (auto &camera : cameras_)
-  {
-    // Render simple RGB data for all cameras
-    mjv_updateScene(mj_model_, mj_data_, &mjv_opt_, NULL, &camera.mjv_cam, mjCAT_ALL, &mjv_scn_);
-    mjr_render(camera.viewport, &mjv_scn_, &mjr_con_);
-
-    // Copy image into relevant buffers
-    mjr_readPixels(
-      camera.image_buffer.data(), camera.depth_buffer.data(), camera.viewport, &mjr_con_);
-
-    // Fix non-linear projections in the depth image and flip the data.
-    // https://github.com/google-deepmind/mujoco/blob/3.2.7/python/mujoco/renderer.py#L190
-    float near = static_cast<float>(mj_model_->vis.map.znear * mj_model_->stat.extent);
-    float far = static_cast<float>(mj_model_->vis.map.zfar * mj_model_->stat.extent);
-    for (uint32_t h = 0; h < camera.height; h++)
-    {
-      for (uint32_t w = 0; w < camera.width; w++)
-      {
-        auto idx = h * camera.width + w;
-        auto idx_flipped = (camera.height - 1 - h) * camera.width + w;
-        camera.depth_buffer[idx] = near / (1.0f - camera.depth_buffer[idx] * (1.0f - near / far));
-        camera.depth_buffer_flipped[idx_flipped] = camera.depth_buffer[idx];
-      }
-    }
-    // Copy flipped data into the depth image message, floats -> unsigned chars
-    std::memcpy(
-      &camera.depth_image.data[0], camera.depth_buffer_flipped.data(),
-      camera.depth_image.data.size());
-
-    // OpenGL's coordinate system's origin is in the bottom left, so we invert the images row-by-row
-    auto row_size = camera.width * 3;
-    for (uint32_t h = 0; h < camera.height; h++)
-    {
-      auto src_idx = h * row_size;
-      auto dest_idx = (camera.height - 1 - h) * row_size;
-      std::memcpy(&camera.image.data[dest_idx], &camera.image_buffer[src_idx], row_size);
-    }
-
-    // Publish images and camera info
-    auto time = node_->now();
-    camera.image.header.stamp = time;
-    camera.depth_image.header.stamp = time;
-    camera.camera_info.header.stamp = time;
-
-    camera.image_pub->publish(camera.image);
-    camera.depth_image_pub->publish(camera.depth_image);
-    camera.camera_info_pub->publish(camera.camera_info);
-  }
 }
 
 void MujocoRendering::close()
@@ -275,78 +209,6 @@ void MujocoRendering::scroll_callback_impl(
 {
   // emulate vertical mouse motion = 5% of window height
   mjv_moveCamera(mj_model_, mjMOUSE_ZOOM, 0, -0.05 * yoffset, &mjv_scn_, &mjv_cam_);
-}
-
-void MujocoRendering::register_cameras()
-{
-  cameras_.resize(0);
-  for (auto i = 0; i < mj_model_->ncam; ++i)
-  {
-    const char *cam_name = mj_model_->names + mj_model_->name_camadr[i];
-    const int *cam_resolution = mj_model_->cam_resolution + 2 * i;
-    const mjtNum cam_fovy = mj_model_->cam_fovy[i];
-
-    // Construct CameraData wrapper and set defaults
-    CameraData camera;
-    camera.name = cam_name;
-    camera.mjv_cam.type = mjCAMERA_FIXED;
-    camera.mjv_cam.fixedcamid = i;
-    camera.width = static_cast<uint32_t>(cam_resolution[0]);
-    camera.height = static_cast<uint32_t>(cam_resolution[1]);
-    camera.viewport = {0, 0, cam_resolution[0], cam_resolution[1]};
-
-    // TODO(eholum): Ensure that the camera is attached to the expected pose.
-    // For now assume that's the case.
-    camera.frame_name = camera.name + "_optical_frame";
-
-    // Configure publishers
-    camera.image_pub = node_->create_publisher<sensor_msgs::msg::Image>(camera.name + "/color", 1);
-    camera.depth_image_pub =
-      node_->create_publisher<sensor_msgs::msg::Image>(camera.name + "/depth", 1);
-    camera.camera_info_pub =
-      node_->create_publisher<sensor_msgs::msg::CameraInfo>(camera.name + "/camera_info", 1);
-
-    // Setup contaienrs for color image data
-    camera.image.header.frame_id = camera.frame_name;
-
-    const auto image_size = camera.width * camera.height * 3;
-    camera.image_buffer.resize(image_size);
-    camera.image.data.resize(image_size);
-    camera.image.width = camera.width;
-    camera.image.height = camera.height;
-    camera.image.step = camera.width * 3;
-    camera.image.encoding = sensor_msgs::image_encodings::RGB8;
-
-    // Depth image data
-    camera.depth_image.header.frame_id = camera.frame_name;
-    camera.depth_buffer.resize(camera.width * camera.height);
-    camera.depth_buffer_flipped.resize(camera.width * camera.height);
-    camera.depth_image.data.resize(camera.width * camera.height * sizeof(float));
-    camera.depth_image.width = camera.width;
-    camera.depth_image.height = camera.height;
-    camera.depth_image.step = camera.width * sizeof(float);
-    camera.depth_image.encoding = sensor_msgs::image_encodings::TYPE_32FC1;
-
-    // Camera info
-    camera.camera_info.header.frame_id = camera.frame_name;
-    camera.camera_info.width = camera.width;
-    camera.camera_info.height = camera.height;
-    camera.camera_info.distortion_model = "plumb_bob";
-    camera.camera_info.k.fill(0.0);
-    camera.camera_info.r.fill(0.0);
-    camera.camera_info.p.fill(0.0);
-    camera.camera_info.d.resize(5, 0.0);
-
-    double focal_scaling = (1.0 / std::tan((cam_fovy * M_PI / 180.0) / 2.0)) * camera.height / 2.0;
-    camera.camera_info.k[0] = camera.camera_info.p[0] = focal_scaling;
-    camera.camera_info.k[2] = camera.camera_info.p[2] = static_cast<double>(camera.width) / 2.0;
-    camera.camera_info.k[4] = camera.camera_info.p[5] = focal_scaling;
-    camera.camera_info.k[5] = camera.camera_info.p[6] = static_cast<double>(camera.height) / 2.0;
-    camera.camera_info.k[8] = camera.camera_info.p[10] = 1.0;
-
-    // Add to list of cameras
-    cameras_.push_back(camera);
-  }
 }
 
 }  // namespace mujoco_ros2_control

--- a/mujoco_ros2_control/src/mujoco_rendering.cpp
+++ b/mujoco_ros2_control/src/mujoco_rendering.cpp
@@ -121,7 +121,7 @@ void MujocoRendering::update_cameras()
   // Rendering is done offscreen
   mjr_setBuffer(mjFB_OFFSCREEN, &mjr_con_);
 
-  for (auto& camera : cameras_)
+  for (auto &camera : cameras_)
   {
     // Render simple RGB data for all cameras
     mjv_updateScene(mj_model_, mj_data_, &mjv_opt_, NULL, &camera.mjv_cam, mjCAT_ALL, &mjv_scn_);
@@ -173,7 +173,8 @@ void MujocoRendering::scroll_callback(GLFWwindow *window, double xoffset, double
   get_instance()->scroll_callback_impl(window, xoffset, yoffset);
 }
 
-void MujocoRendering::keyboard_callback_impl(GLFWwindow* /* window */, int key, int /* scancode */, int act, int /* mods */)
+void MujocoRendering::keyboard_callback_impl(
+  GLFWwindow * /* window */, int key, int /* scancode */, int act, int /* mods */)
 {
   // backspace: reset simulation
   if (act == GLFW_PRESS && key == GLFW_KEY_BACKSPACE)
@@ -183,7 +184,8 @@ void MujocoRendering::keyboard_callback_impl(GLFWwindow* /* window */, int key, 
   }
 }
 
-void MujocoRendering::mouse_button_callback_impl(GLFWwindow* window, int /* button */, int /* act */, int /* mods */)
+void MujocoRendering::mouse_button_callback_impl(
+  GLFWwindow *window, int /* button */, int /* act */, int /* mods */)
 {
   // update button state
   button_left_ = (glfwGetMouseButton(window, GLFW_MOUSE_BUTTON_LEFT) == GLFW_PRESS);
@@ -236,7 +238,8 @@ void MujocoRendering::mouse_move_callback_impl(GLFWwindow *window, double xpos, 
   mjv_moveCamera(mj_model_, action, dx / height, dy / height, &mjv_scn_, &mjv_cam_);
 }
 
-void MujocoRendering::scroll_callback_impl(GLFWwindow* /* window */, double /* xoffset */, double yoffset)
+void MujocoRendering::scroll_callback_impl(
+  GLFWwindow * /* window */, double /* xoffset */, double yoffset)
 {
   // emulate vertical mouse motion = 5% of window height
   mjv_moveCamera(mj_model_, mjMOUSE_ZOOM, 0, -0.05 * yoffset, &mjv_scn_, &mjv_cam_);
@@ -247,9 +250,9 @@ void MujocoRendering::register_cameras()
   cameras_.resize(0);
   for (auto i = 0; i < mj_model_->ncam; ++i)
   {
-    const char * cam_name = mj_model_->names + mj_model_->name_camadr[i];
-    const int * cam_resolution = mj_model_->cam_resolution + 2 * i;
-    const float * cam_intrinsic = mj_model_->cam_intrinsic + 4 * i;
+    const char *cam_name = mj_model_->names + mj_model_->name_camadr[i];
+    const int *cam_resolution = mj_model_->cam_resolution + 2 * i;
+    const float *cam_intrinsic = mj_model_->cam_intrinsic + 4 * i;
 
     auto fx = static_cast<double>(cam_intrinsic[0]);
     auto fy = static_cast<double>(cam_intrinsic[1]);
@@ -263,16 +266,18 @@ void MujocoRendering::register_cameras()
     camera.mjv_cam.fixedcamid = i;
     camera.width = static_cast<uint32_t>(cam_resolution[0]);
     camera.height = static_cast<uint32_t>(cam_resolution[1]);
-    camera.viewport = { 0, 0, cam_resolution[0], cam_resolution[1] };
+    camera.viewport = {0, 0, cam_resolution[0], cam_resolution[1]};
 
-    // TODO: Ensure that the camera is attached to the expected pose. For now assume that's the case.
+    // TODO(eholum): Ensure that the camera is attached to the expected pose.
+    // For now assume that's the case.
     camera.frame_name = camera.name + "_optical_frame";
     camera.image.header.frame_id = camera.frame_name;
     camera.camera_info.header.frame_id = camera.frame_name;
 
     // Configure publishers
     camera.image_pub = node_->create_publisher<sensor_msgs::msg::Image>(camera.name + "/color", 10);
-    camera.camera_info_pub = node_->create_publisher<sensor_msgs::msg::CameraInfo>(camera.name + "/camera_info", 10);
+    camera.camera_info_pub =
+      node_->create_publisher<sensor_msgs::msg::CameraInfo>(camera.name + "/camera_info", 10);
 
     // Set defaults for the image and camera_info, hardcoding for now
     camera.image.data.resize(camera.width * camera.height * 3);
@@ -294,10 +299,10 @@ void MujocoRendering::register_cameras()
     camera.camera_info.k[8] = 1.0;
 
     camera.camera_info.p.fill(0.0);
-    camera.camera_info.p[0]  = fx;
-    camera.camera_info.p[2]  = cx;
-    camera.camera_info.p[5]  = fy;
-    camera.camera_info.p[6]  = cy;
+    camera.camera_info.p[0] = fx;
+    camera.camera_info.p[2] = cx;
+    camera.camera_info.p[5] = fy;
+    camera.camera_info.p[6] = cy;
     camera.camera_info.p[10] = 1.0;
 
     camera.camera_info.r.fill(0.0);
@@ -310,4 +315,4 @@ void MujocoRendering::register_cameras()
   }
 }
 
-} // namespace mujoco_ros2_control
+}  // namespace mujoco_ros2_control

--- a/mujoco_ros2_control/src/mujoco_ros2_control_node.cpp
+++ b/mujoco_ros2_control/src/mujoco_ros2_control_node.cpp
@@ -87,8 +87,8 @@ int main(int argc, const char **argv)
     rendering->update();
 
     // Updating cameras at ~6 Hz
-    // TODO: Break control and rendering into separate processes
-    if (simstart - last_cam_update > 1.0/6.0)
+    // TODO(eholum): Break control and rendering into separate processes
+    if (simstart - last_cam_update > 1.0 / 6.0)
     {
       rendering->update_cameras();
       last_cam_update = simstart;

--- a/mujoco_ros2_control/src/mujoco_ros2_control_node.cpp
+++ b/mujoco_ros2_control/src/mujoco_ros2_control_node.cpp
@@ -76,8 +76,8 @@ int main(int argc, const char **argv)
   rendering->init(mujoco_model, mujoco_data);
   RCLCPP_INFO_STREAM(node->get_logger(), "Mujoco rendering has been successfully initialized !");
 
-  auto cameras = std::make_unique<mujoco_ros2_control::MujocoCameras>();
-  cameras->init(node, mujoco_model, mujoco_data);
+  auto cameras = std::make_unique<mujoco_ros2_control::MujocoCameras>(node);
+  cameras->init(mujoco_model);
 
   // run main loop, target real-time simulation and 60 fps rendering with cameras around 6 hz
   mjtNum last_cam_update = mujoco_data->time;
@@ -98,7 +98,7 @@ int main(int argc, const char **argv)
     // TODO(eholum): Break control and rendering into separate processes
     if (simstart - last_cam_update > 1.0 / 6.0)
     {
-      cameras->update_cameras();
+      cameras->update(mujoco_model, mujoco_data);
       last_cam_update = simstart;
     }
   }

--- a/mujoco_ros2_control/src/mujoco_ros2_control_node.cpp
+++ b/mujoco_ros2_control/src/mujoco_ros2_control_node.cpp
@@ -104,6 +104,7 @@ int main(int argc, const char **argv)
   }
 
   rendering->close();
+  cameras->close();
 
   // free MuJoCo model and data
   mj_deleteData(mujoco_data);

--- a/mujoco_ros2_control/src/mujoco_ros2_control_node.cpp
+++ b/mujoco_ros2_control/src/mujoco_ros2_control_node.cpp
@@ -71,7 +71,8 @@ int main(int argc, const char **argv)
   rendering->init(node, mujoco_model, mujoco_data);
   RCLCPP_INFO_STREAM(node->get_logger(), "Mujoco rendering has been successfully initialized !");
 
-  // run main loop, target real-time simulation and 60 fps rendering
+  // run main loop, target real-time simulation and 60 fps rendering with cameras around 6 hz
+  mjtNum last_cam_update = mujoco_data->time;
   while (rclcpp::ok() && !rendering->is_close_flag_raised())
   {
     // advance interactive simulation for 1/60 sec
@@ -84,6 +85,14 @@ int main(int argc, const char **argv)
       control.update();
     }
     rendering->update();
+
+    // Updating cameras at ~6 Hz
+    // TODO: Break control and rendering into separate processes
+    if (simstart - last_cam_update > 1.0/6.0)
+    {
+      rendering->update_cameras();
+      last_cam_update = simstart;
+    }
   }
 
   rendering->close();

--- a/mujoco_ros2_control_demos/CMakeLists.txt
+++ b/mujoco_ros2_control_demos/CMakeLists.txt
@@ -52,6 +52,9 @@ ament_target_dependencies(example_tricycle_drive ${THIS_PACKAGE_DEPENDS})
 add_executable(example_gripper examples/example_gripper.cpp)
 ament_target_dependencies(example_gripper ${THIS_PACKAGE_DEPENDS})
 
+add_executable(example_camera examples/example_camera.cpp)
+ament_target_dependencies(example_camera ${THIS_PACKAGE_DEPENDS})
+
 install(TARGETS
     example_position
     example_velocity
@@ -59,6 +62,7 @@ install(TARGETS
     example_diff_drive
     example_tricycle_drive
     example_gripper
+    example_camera
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/mujoco_ros2_control_demos/config/camera_controller_position.yaml
+++ b/mujoco_ros2_control_demos/config/camera_controller_position.yaml
@@ -1,0 +1,14 @@
+controller_manager:
+  ros__parameters:
+    update_rate: 50
+
+    position_controller:
+      type: joint_trajectory_controller/JointTrajectoryController
+
+    position_controller:
+      type: position_controllers/JointGroupPositionController
+
+position_controller:
+  ros__parameters:
+    joints:
+      - camera_joint

--- a/mujoco_ros2_control_demos/config/camera_controller_position.yaml
+++ b/mujoco_ros2_control_demos/config/camera_controller_position.yaml
@@ -2,8 +2,8 @@ controller_manager:
   ros__parameters:
     update_rate: 50
 
-    position_controller:
-      type: joint_trajectory_controller/JointTrajectoryController
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateBroadcaster
 
     position_controller:
       type: position_controllers/JointGroupPositionController

--- a/mujoco_ros2_control_demos/examples/example_camera.cpp
+++ b/mujoco_ros2_control_demos/examples/example_camera.cpp
@@ -1,16 +1,22 @@
-// Copyright 2022 Open Source Robotics Foundation, Inc.
+// Copyright (c) 2025 Erik Holum
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 
 #include <chrono>
 #include <cmath>

--- a/mujoco_ros2_control_demos/examples/example_camera.cpp
+++ b/mujoco_ros2_control_demos/examples/example_camera.cpp
@@ -11,3 +11,50 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+#include <chrono>
+#include <cmath>
+
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/float64_multi_array.hpp"
+
+using namespace std::chrono_literals;
+
+class CameraJointPublisher : public rclcpp::Node
+{
+public:
+  CameraJointPublisher() : Node("camera_joint_publisher")
+  {
+    publisher_ =
+      this->create_publisher<std_msgs::msg::Float64MultiArray>("/position_controller/commands", 10);
+    start_time_ = this->now();
+    timer_ = this->create_wall_timer(100ms, std::bind(&CameraJointPublisher::timer_callback, this));
+  }
+
+private:
+  void timer_callback()
+  {
+    double elapsed = (this->now() - start_time_).seconds();
+    double period = 3.0;
+    double amplitude = 0.2;
+    double angle = amplitude * std::sin(2 * M_PI * elapsed / period);
+
+    std_msgs::msg::Float64MultiArray msg;
+    msg.data.push_back(angle);
+
+    publisher_->publish(msg);
+    RCLCPP_INFO(this->get_logger(), "Publishing angle: %.3f", angle);
+  }
+
+  rclcpp::Publisher<std_msgs::msg::Float64MultiArray>::SharedPtr publisher_;
+  rclcpp::TimerBase::SharedPtr timer_;
+  rclcpp::Time start_time_;
+};
+
+int main(int argc, char *argv[])
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<CameraJointPublisher>());
+  rclcpp::shutdown();
+  return 0;
+}

--- a/mujoco_ros2_control_demos/examples/example_camera.cpp
+++ b/mujoco_ros2_control_demos/examples/example_camera.cpp
@@ -1,0 +1,13 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.

--- a/mujoco_ros2_control_demos/launch/camera_demo.rviz
+++ b/mujoco_ros2_control_demos/launch/camera_demo.rviz
@@ -186,25 +186,25 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz_default_plugins/Orbit
-      Distance: 3.0831525325775146
+      Distance: 2.5519511699676514
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
         Swap Stereo Eyes: false
         Value: false
       Focal Point:
-        X: 0.1265479177236557
-        Y: 0.18052245676517487
-        Z: 0.15627193450927734
+        X: 0.15866273641586304
+        Y: 0.23128746449947357
+        Z: 0.28159964084625244
       Focal Shape Fixed Size: true
       Focal Shape Size: 0.05000000074505806
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Pitch: 0.5247969031333923
+      Pitch: 0.4447966516017914
       Target Frame: <Fixed Frame>
       Value: Orbit (rviz)
-      Yaw: 4.5885748863220215
+      Yaw: 4.253581523895264
     Saved: ~
 Window Geometry:
   Camera:

--- a/mujoco_ros2_control_demos/launch/camera_demo.rviz
+++ b/mujoco_ros2_control_demos/launch/camera_demo.rviz
@@ -1,0 +1,228 @@
+Panels:
+  - Class: rviz_common/Displays
+    Help Height: 0
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+        - /Camera1
+        - /Camera2
+        - /TF1/Frames1
+      Splitter Ratio: 0.5
+    Tree Height: 629
+  - Class: rviz_common/Selection
+    Name: Selection
+  - Class: rviz_common/Tool Properties
+    Expanded:
+      - /2D Goal Pose1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz_common/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz_common/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: DepthCloud
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Class: rviz_default_plugins/Camera
+      Enabled: true
+      Far Plane Distance: 100
+      Image Rendering: background and overlay
+      Name: Camera
+      Overlay Alpha: 0.5
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /camera/color
+      Value: true
+      Visibility:
+        Camera: true
+        DepthCloud: true
+        TF: true
+        Value: true
+      Zoom Factor: 1
+    - Class: rviz_default_plugins/Camera
+      Enabled: true
+      Far Plane Distance: 100
+      Image Rendering: background and overlay
+      Name: Camera
+      Overlay Alpha: 0.5
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /camera/depth
+      Value: true
+      Visibility:
+        Camera: true
+        DepthCloud: true
+        TF: true
+        Value: true
+      Zoom Factor: 1
+    - Class: rviz_default_plugins/TF
+      Enabled: true
+      Frame Timeout: 15
+      Frames:
+        All Enabled: false
+        base_link:
+          Value: false
+        camera:
+          Value: false
+        camera_optical_frame:
+          Value: true
+        green_sphere:
+          Value: true
+        red_box:
+          Value: true
+      Marker Scale: 1
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: false
+      Tree:
+        base_link:
+          camera:
+            camera_optical_frame:
+              {}
+          green_sphere:
+            {}
+          red_box:
+            {}
+      Update Interval: 0
+      Value: true
+    - Alpha: 1
+      Auto Size:
+        Auto Size Factor: 1
+        Value: true
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz_default_plugins/DepthCloud
+      Color: 255; 255; 255
+      Color Image Topic: /camera/color
+      Color Transformer: RGB8
+      Color Transport Hint: raw
+      Decay Time: 0
+      Depth Map Topic: /camera/depth
+      Depth Map Transport Hint: raw
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: DepthCloud
+      Occlusion Compensation:
+        Occlusion Time-Out: 30
+        Value: false
+      Position Transformer: XYZ
+      Queue Size: 5
+      Reliability Policy: Best effort
+      Selectable: true
+      Size (Pixels): 3
+      Style: Flat Squares
+      Topic Filter: true
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Fixed Frame: base_link
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz_default_plugins/Interact
+      Hide Inactive Objects: true
+    - Class: rviz_default_plugins/MoveCamera
+    - Class: rviz_default_plugins/Select
+    - Class: rviz_default_plugins/FocusCamera
+    - Class: rviz_default_plugins/Measure
+      Line color: 128; 128; 0
+    - Class: rviz_default_plugins/SetInitialPose
+      Covariance x: 0.25
+      Covariance y: 0.25
+      Covariance yaw: 0.06853891909122467
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /initialpose
+    - Class: rviz_default_plugins/SetGoal
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /goal_pose
+    - Class: rviz_default_plugins/PublishPoint
+      Single click: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /clicked_point
+  Transformation:
+    Current:
+      Class: rviz_default_plugins/TF
+  Value: true
+  Views:
+    Current:
+      Class: rviz_default_plugins/Orbit
+      Distance: 3.0831525325775146
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: 0.1265479177236557
+        Y: 0.18052245676517487
+        Z: 0.15627193450927734
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.5247969031333923
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 4.5885748863220215
+    Saved: ~
+Window Geometry:
+  Camera:
+    collapsed: false
+  Displays:
+    collapsed: false
+  Height: 842
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd00000004000000000000018e000002b0fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003b000002b0000000c700fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000025f000002b0fc0200000008fb0000000c00430061006d006500720061010000003b000001490000002800fffffffb0000000c00430061006d006500720061010000018a000001610000002800fffffffb0000000c00430061006d0065007200610100000169000001820000000000000000fb0000000c00430061006d00650072006101000001b9000001320000000000000000fb0000000a0049006d006100670065010000003b000002b00000000000000000fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003b000002b0000000a000fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000005a20000003efc0100000002fb0000000800540069006d00650100000000000005a20000025300fffffffb0000000800540069006d00650100000000000004500000000000000000000001a9000002b000000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1442
+  X: 70
+  Y: 27

--- a/mujoco_ros2_control_demos/launch/camera_example.launch.py
+++ b/mujoco_ros2_control_demos/launch/camera_example.launch.py
@@ -1,0 +1,39 @@
+import os
+
+from ament_index_python.packages import get_package_share_directory
+
+
+from launch import LaunchDescription
+from launch.actions import ExecuteProcess, RegisterEventHandler
+from launch.event_handlers import OnProcessStart, OnProcessExit
+
+from launch_ros.actions import Node
+
+import xacro
+
+
+def generate_launch_description():
+    mujoco_ros2_control_demos_path = os.path.join(
+        get_package_share_directory('mujoco_ros2_control_demos'))
+
+    xacro_file = os.path.join(mujoco_ros2_control_demos_path,
+                              'urdf',
+                              'test_camera.xacro.urdf')
+
+    doc = xacro.parse(open(xacro_file))
+    xacro.process_doc(doc)
+    robot_description = {'robot_description': doc.toxml()}
+
+    node_mujoco_ros2_control = Node(
+        package='mujoco_ros2_control',
+        executable='mujoco_ros2_control',
+        output='screen',
+        parameters=[
+            robot_description,
+            {'mujoco_model_path':os.path.join(mujoco_ros2_control_demos_path, 'mujoco_models', 'test_camera.xml')}
+        ]
+    )
+
+    return LaunchDescription([
+        node_mujoco_ros2_control,
+    ])

--- a/mujoco_ros2_control_demos/launch/camera_example.launch.py
+++ b/mujoco_ros2_control_demos/launch/camera_example.launch.py
@@ -20,6 +20,8 @@ def generate_launch_description():
                               'urdf',
                               'test_camera.xacro.urdf')
 
+    controller_config_file = os.path.join(mujoco_ros2_control_demos_path, 'config', 'camera_controller_position.yaml')
+
     doc = xacro.parse(open(xacro_file))
     xacro.process_doc(doc)
     robot_description = {'robot_description': doc.toxml()}
@@ -30,10 +32,43 @@ def generate_launch_description():
         output='screen',
         parameters=[
             robot_description,
+            controller_config_file,
             {'mujoco_model_path':os.path.join(mujoco_ros2_control_demos_path, 'mujoco_models', 'test_camera.xml')}
         ]
     )
 
+    node_robot_state_publisher = Node(
+        package='robot_state_publisher',
+        executable='robot_state_publisher',
+        output='screen',
+        parameters=[robot_description]
+    )
+
+    load_joint_state_controller = ExecuteProcess(
+        cmd=['ros2', 'control', 'load_controller', '--set-state', 'active',
+             'joint_state_broadcaster'],
+        output='screen'
+    )
+
+    load_position_controller = ExecuteProcess(
+        cmd=['ros2', 'control', 'load_controller', '--set-state', 'active',
+             'position_controller'],
+        output='screen'
+    )
+
     return LaunchDescription([
+        RegisterEventHandler(
+            event_handler=OnProcessStart(
+                target_action=node_mujoco_ros2_control,
+                on_start=[load_joint_state_controller],
+            )
+        ),
+        RegisterEventHandler(
+            event_handler=OnProcessExit(
+                target_action=load_joint_state_controller,
+                on_exit=[load_position_controller],
+            )
+        ),
         node_mujoco_ros2_control,
+        node_robot_state_publisher,
     ])

--- a/mujoco_ros2_control_demos/launch/camera_example.launch.py
+++ b/mujoco_ros2_control_demos/launch/camera_example.launch.py
@@ -1,7 +1,7 @@
 import os
+import xacro
 
 from ament_index_python.packages import get_package_share_directory
-
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess, RegisterEventHandler
@@ -9,22 +9,26 @@ from launch.event_handlers import OnProcessStart, OnProcessExit
 
 from launch_ros.actions import Node
 
-import xacro
-
 
 def generate_launch_description():
+
     mujoco_ros2_control_demos_path = os.path.join(
         get_package_share_directory('mujoco_ros2_control_demos'))
-
     xacro_file = os.path.join(mujoco_ros2_control_demos_path,
                               'urdf',
                               'test_camera.xacro.urdf')
-
-    controller_config_file = os.path.join(mujoco_ros2_control_demos_path, 'config', 'camera_controller_position.yaml')
+    controller_config_file = os.path.join(mujoco_ros2_control_demos_path,
+                                          'config',
+                                          'camera_controller_position.yaml')
+    rviz_config_file = os.path.join(mujoco_ros2_control_demos_path,
+                                          'launch',
+                                          'camera_demo.rviz')
 
     doc = xacro.parse(open(xacro_file))
     xacro.process_doc(doc)
     robot_description = {'robot_description': doc.toxml()}
+
+    use_sim_time = {'use_sim_time': True}
 
     node_mujoco_ros2_control = Node(
         package='mujoco_ros2_control',
@@ -33,7 +37,8 @@ def generate_launch_description():
         parameters=[
             robot_description,
             controller_config_file,
-            {'mujoco_model_path':os.path.join(mujoco_ros2_control_demos_path, 'mujoco_models', 'test_camera.xml')}
+            use_sim_time,
+            {'mujoco_model_path' : os.path.join(mujoco_ros2_control_demos_path, 'mujoco_models', 'test_camera.xml')}
         ]
     )
 
@@ -41,7 +46,10 @@ def generate_launch_description():
         package='robot_state_publisher',
         executable='robot_state_publisher',
         output='screen',
-        parameters=[robot_description]
+        parameters=[
+            use_sim_time,
+            robot_description,
+        ]
     )
 
     load_joint_state_controller = ExecuteProcess(
@@ -54,6 +62,15 @@ def generate_launch_description():
         cmd=['ros2', 'control', 'load_controller', '--set-state', 'active',
              'position_controller'],
         output='screen'
+    )
+
+    rviz_node = Node(
+        package="rviz2",
+        executable="rviz2",
+        name="rviz2",
+        output="screen",
+        parameters=[use_sim_time],
+        arguments=["-d", rviz_config_file],
     )
 
     return LaunchDescription([
@@ -71,4 +88,5 @@ def generate_launch_description():
         ),
         node_mujoco_ros2_control,
         node_robot_state_publisher,
+        rviz_node,
     ])

--- a/mujoco_ros2_control_demos/mujoco_models/test_camera.xml
+++ b/mujoco_ros2_control_demos/mujoco_models/test_camera.xml
@@ -1,0 +1,25 @@
+<mujoco model="test_camera">
+
+    <visual>
+        <headlight ambient="0.7 0.7 0.7" diffuse="0.2 0.2 0.2" specular="0.1 0.1 0.1"/>
+        <map znear="0.01"/>
+        <scale contactwidth="0.02" contactheight="0.5"/>
+        <rgba rangefinder="1 1 0.1 0.1"/>
+    </visual>
+
+    <worldbody>
+        <geom name="red_box" type="box" size=".1 .1 .1" rgba="1 0 0 1"/>
+        <geom name="green_sphere" pos="0.3 0.3 0.3" size=".1" rgba="0 1 0 1"/>
+
+        <body name="camera" pos="0 0 1" euler="0 0 0">
+            <camera name="camera" fovy="58" mode="fixed" resolution="640 480" />
+            <site name="camera_optical_frame" size="0.03" />
+            <body name="camera_marker" pos="0 0 0.05">
+                <geom type="box" size="0.08 0.05 0.03" mass="1.0" rgba="0.5 0.5 1.0 1.0"/>
+                <geom type="box" size="0.01 0.01 0.01" mass="0.0" rgba="0.5 0.5 1.0 1.0" pos="0.04 0.055 0"/>
+                <geom type="cylinder" size="0.03 0.01" mass="0.0" rgba="0.5 0.5 1.0 1.0" pos="0 0 -0.04"/>
+            </body>
+        </body>
+    </worldbody>
+
+</mujoco>

--- a/mujoco_ros2_control_demos/mujoco_models/test_camera.xml
+++ b/mujoco_ros2_control_demos/mujoco_models/test_camera.xml
@@ -12,6 +12,7 @@
         <geom name="green_sphere" pos="0.3 0.3 0.3" size=".1" rgba="0 1 0 1"/>
 
         <body name="camera" pos="0 0 1" euler="0 0 0">
+            <joint name="camera_joint" type="hinge" axis="0 1 0" range="-30 30" damping="0.1"/>
             <camera name="camera" fovy="58" mode="fixed" resolution="640 480" />
             <site name="camera_optical_frame" size="0.03" />
             <body name="camera_marker" pos="0 0 0.05">
@@ -21,5 +22,9 @@
             </body>
         </body>
     </worldbody>
+
+    <actuator>
+        <motor joint="camera_joint" ctrlrange="-1 1" gear="100"/>
+    </actuator>
 
 </mujoco>

--- a/mujoco_ros2_control_demos/package.xml
+++ b/mujoco_ros2_control_demos/package.xml
@@ -23,6 +23,8 @@
  <depend>velocity_controllers</depend>
  <depend>force_torque_sensor_broadcaster</depend>
 
+ <exec_depend>position_controllers</exec_depend>
+
  <test_depend>ament_lint_auto</test_depend>
  <test_depend>ament_cmake_clang_format</test_depend>
  <test_depend>ament_cmake_cppcheck</test_depend>

--- a/mujoco_ros2_control_demos/urdf/test_camera.xacro.urdf
+++ b/mujoco_ros2_control_demos/urdf/test_camera.xacro.urdf
@@ -48,16 +48,23 @@
   <joint name="camera_joint" type="revolute">
     <parent link="base_link"/>
     <child link="camera"/>
-    <origin xyz="0 0 1" rpy="0 1.5708 1.5708"/>
-    <axis xyz="0 0 1"/>
-    <limit lower="-0.5" upper="0.5" effort="1" velocity="1"/>
+    <origin xyz="0 0 1" rpy="0 0 0"/>
+    <axis xyz="0 1 0"/>
+    <limit lower="-0.5236" upper="0.5236" effort="1" velocity="1"/>
   </joint>
 
+  <!--
+  Mujoco camera conventions have the z-frame pointed into the camera, whereas
+  ROS conventions expects the opposite. We adjust for that here.
+
+  https://mujoco.readthedocs.io/en/3.2.7/modeling.html#cameras
+  https://github.com/ros2/common_interfaces/blob/22012ae1f60903e100aca2765f17ad6a62e6777a/sensor_msgs/msg/Image.msg#L4
+  -->
   <link name="camera_optical_frame" />
   <joint name="camera_optical_joint" type="fixed">
     <parent link="camera"/>
     <child link="camera_optical_frame"/>
-    <origin xyz="0 0 0" rpy="-1.5708 0 -1.5708"/>
+    <origin xyz="0 0 0" rpy="3.14159 0 0"/>
     <axis xyz="0 0 0"/>
   </joint>
 

--- a/mujoco_ros2_control_demos/urdf/test_camera.xacro.urdf
+++ b/mujoco_ros2_control_demos/urdf/test_camera.xacro.urdf
@@ -1,0 +1,63 @@
+<?xml version="1.0" ?>
+<robot name="camera" >
+
+  <link name="base_link" />
+
+  <link name="red_box">
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <box size="0.2 0.2 0.2"/>
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1"/>
+      </material>
+    </visual>
+  </link>
+
+  <joint name="red_box_joint" type="fixed">
+    <parent link="base_link"/>
+    <child link="red_box"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+  </joint>
+
+  <link name="green_sphere">
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="0.1"/>
+      </geometry>
+      <material name="green">
+        <color rgba="0 1 0 1"/>
+      </material>
+    </visual>
+  </link>
+
+  <joint name="green_sphere_joint" type="fixed">
+    <parent link="base_link"/>
+    <child link="green_sphere"/>
+    <origin xyz="0.3 0.3 0.3" rpy="0 0 0"/>
+  </joint>
+
+  <link name="camera">
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <box size="0.05 0.05 0.05"/>
+      </geometry>
+    </visual>
+  </link>
+
+  <joint name="camera_joint" type="fixed">
+    <parent link="base_link"/>
+    <child link="camera"/>
+    <origin xyz="0 0 1" rpy="0 0 0"/>
+  </joint>
+
+  <ros2_control name="MujocoSystem" type="system">
+    <hardware>
+      <plugin>mujoco_ros2_control/MujocoSystem</plugin>
+    </hardware>
+  </ros2_control>
+
+</robot>

--- a/mujoco_ros2_control_demos/urdf/test_camera.xacro.urdf
+++ b/mujoco_ros2_control_demos/urdf/test_camera.xacro.urdf
@@ -14,7 +14,6 @@
       </material>
     </visual>
   </link>
-
   <joint name="red_box_joint" type="fixed">
     <parent link="base_link"/>
     <child link="red_box"/>
@@ -32,7 +31,6 @@
       </material>
     </visual>
   </link>
-
   <joint name="green_sphere_joint" type="fixed">
     <parent link="base_link"/>
     <child link="green_sphere"/>
@@ -47,13 +45,20 @@
       </geometry>
     </visual>
   </link>
-
   <joint name="camera_joint" type="revolute">
     <parent link="base_link"/>
     <child link="camera"/>
-    <origin xyz="0 0 1" rpy="0 0 0"/>
-    <axis xyz="0 1 0"/>
+    <origin xyz="0 0 1" rpy="0 1.5708 1.5708"/>
+    <axis xyz="0 0 1"/>
     <limit lower="-0.5" upper="0.5" effort="1" velocity="1"/>
+  </joint>
+
+  <link name="camera_optical_frame" />
+  <joint name="camera_optical_joint" type="fixed">
+    <parent link="camera"/>
+    <child link="camera_optical_frame"/>
+    <origin xyz="0 0 0" rpy="-1.5708 0 -1.5708"/>
+    <axis xyz="0 0 0"/>
   </joint>
 
   <ros2_control name="MujocoSystem" type="system">

--- a/mujoco_ros2_control_demos/urdf/test_camera.xacro.urdf
+++ b/mujoco_ros2_control_demos/urdf/test_camera.xacro.urdf
@@ -48,16 +48,24 @@
     </visual>
   </link>
 
-  <joint name="camera_joint" type="fixed">
+  <joint name="camera_joint" type="revolute">
     <parent link="base_link"/>
     <child link="camera"/>
     <origin xyz="0 0 1" rpy="0 0 0"/>
+    <axis xyz="0 1 0"/>
+    <limit lower="-0.5" upper="0.5" effort="1" velocity="1"/>
   </joint>
 
   <ros2_control name="MujocoSystem" type="system">
     <hardware>
       <plugin>mujoco_ros2_control/MujocoSystem</plugin>
     </hardware>
+    <joint name="camera_joint">
+      <command_interface name="position" />
+      <state_interface name="position">
+        <param name="initial_value">0.0</param>
+      </state_interface>
+    </joint>
   </ros2_control>
 
 </robot>


### PR DESCRIPTION
Resolves https://github.com/moveit/mujoco_ros2_control/issues/23, at least a good chunk of it.

For now going to stop poking at this and look to get some feedback.

This PR adds basic RGB-D camera support to the drivers by parsing cameras out of the mujoco model and converting them to ROS constructs. In summary, this PR,

* Adds the `MujocoCameras` module for handling images/depth info from the sim
  * Handles conversion of data from OpenGL/Mujoco to ROS standards
  * Publishes camera info and images to appropriate topics
  * Theoretically supports many cameras
* Adds an example for using camera images
  * Includes a hinge joint just so that we can actually see images updating rather than just a static ball and box (run the demo)
  * Added Rviz config and launch, not sure if we want this or not, but it's handy for showing how things are setup
* Configuration options are very much hardcoded for now, but I think that's fine for initial support

To run the example,

```bash
# Start the sim and launch rviz
ros2 launch mujoco_ros2_control_demos camera_example.launch.py 

# Have the camera swing back and forth
ros2 run mujoco_ros2_control_demos example_camera
```

As mentioned above, there's definitely some more work we could do on top of this, some thoughts:

* Investigate further separation of rendering vs cameras vs control
  * All the work is done in that one loop, but we could experiment with this 
* More configuration options for cameras
  * Update rates
  * Making more things optional
  * Different topics  
* Add a demo for depth map to point cloud republishers

<img width="1390" alt="image" src="https://github.com/user-attachments/assets/dcd0521c-74fc-4a84-b04f-73331c4482e1" />

