### PR TITLE
Fix out-of-range error in register_sensors by replacing incorrect ind…

### DIFF
--- a/mujoco_ros2_control/src/mujoco_system.cpp
+++ b/mujoco_ros2_control/src/mujoco_system.cpp
@@ -368,7 +368,7 @@ void MujocoSystem::register_sensors(
       sensor_data.torque.mj_sensor_index = mj_model_->sensor_adr[torque_sensor_id];
 
       ft_sensor_data_.push_back(sensor_data);
-      auto &last_sensor_data = ft_sensor_data_.at(sensor_index);
+      auto &last_sensor_data = ft_sensor_data_.back();
 
       for (const auto &state_if : sensor.state_interfaces)
       {
@@ -430,7 +430,8 @@ void MujocoSystem::register_sensors(
       sensor_data.linear_acceleration.mj_sensor_index = mj_model_->sensor_adr[accel_id];
 
       imu_sensor_data_.push_back(sensor_data);
-      auto &last_sensor_data = imu_sensor_data_.at(sensor_index);
+      auto &last_sensor_data = imu_sensor_data_.back();
+
 
       for (const auto &state_if : sensor.state_interfaces)
       {


### PR DESCRIPTION
### Bug Fix: Sensor Index Out-of-Range in `register_sensors`

This PR fixes a runtime crash in `mujoco_ros2_control` when using more than one sensor type (e.g., IMU + FTS). The error:
`terminate called after throwing an instance of 'std::out_of_range'
what(): vector::_M_range_check: __n (which is 1) >= this->size() (which is 1)`

#### Root Cause:
`register_sensors()` was using `sensor_index` (from all sensors) to index into sensor-type-specific vectors like `ft_sensor_data_` and `imu_sensor_data_`.

This caused an out-of-bounds access when the sensor list had mixed sensor types.

#### Fix:
Replaced:
`auto &last_sensor_data = ft_sensor_data_.at(sensor_index);`
with:
`auto &last_sensor_data = ft_sensor_data_.back();
`
(similar for IMU)

#### Tested with:
- 1 IMU and 1 FTS sensor
- Working URDF and MuJoCo configuration
- Successfully launched with no crash