### PR TITLE
Ground truth odometry publisher

### DIFF
--- a/mujoco_ros2_control/CMakeLists.txt
+++ b/mujoco_ros2_control/CMakeLists.txt
@@ -76,6 +76,7 @@ add_executable(mujoco_ros2_control
   src/mujoco_rendering.cpp
   src/mujoco_ros2_control.cpp
   src/mujoco_cameras.cpp
+  src/mujoco_mocap.cpp
 )
 ament_target_dependencies(mujoco_ros2_control ${THIS_PACKAGE_DEPENDS})
 target_link_libraries(mujoco_ros2_control ${MUJOCO_LIB} glfw)

--- a/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_mocap.hpp
+++ b/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_mocap.hpp
@@ -1,0 +1,76 @@
+// Copyright (c) 2025 Akiyoshi UCHIDA
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "mujoco/mujoco.h"
+#include "rclcpp/rclcpp.hpp"
+
+#include "rclcpp/node.hpp"
+#include "rclcpp/publisher.hpp"
+
+#include "geometry_msgs/msg/accel_stamped.hpp"
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "geometry_msgs/msg/twist_stamped.hpp"
+
+namespace mujoco_ros2_control
+{
+
+struct MocapData
+{
+  std::string name;
+  std::string frame_name;
+
+  geometry_msgs::msg::PoseStamped pose;
+  geometry_msgs::msg::TwistStamped twist;
+  geometry_msgs::msg::AccelStamped accel;
+
+  rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr pose_pub;
+  rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr twist_pub;
+  rclcpp::Publisher<geometry_msgs::msg::AccelStamped>::SharedPtr accel_pub;
+};
+
+/**
+ * @brief Class to handle mocap data from MuJoCo and publish it as ROS messages.
+ * Note that this is different from the MuJoCo motion capture body, as it processes data from an
+ * external streaming motion capture.
+ */
+class MujocoMocap
+{
+public:
+  explicit MujocoMocap(rclcpp::Node::SharedPtr &node);
+
+  void init(mjModel *mujoco_model);
+  void update(mjModel *mujoco_model, mjData *mujoco_data);
+  void close();
+
+private:
+  void register_mocap_targets(const mjModel *mujoco_model);
+
+  rclcpp::Node::SharedPtr node_;
+
+  // Containers for mocap target data and ROS constructs
+  std::vector<MocapData> mocap_targets_;
+};
+
+}  // namespace mujoco_ros2_control

--- a/mujoco_ros2_control/src/mujoco_mocap.cpp
+++ b/mujoco_ros2_control/src/mujoco_mocap.cpp
@@ -37,9 +37,8 @@ void MujocoMocap::update(mjModel *mujoco_model, mjData *mujoco_data)
   {
     // Update pose, twist, and acceleration data in global frame
     int body_id = mj_name2id(mujoco_model, mjOBJ_BODY, target.name.c_str());
-    mjtNum *pos = mujoco_data->xpos + 3 * mujoco_model->body_jntadr[body_id];
-    mjtNum *quat = mujoco_data->xquat + 4 * mujoco_model->body_jntadr[body_id];
-    mjtNum *vel = mujoco_data->qvel + mujoco_model->nv * mujoco_model->body_jntadr[body_id];
+    mjtNum *pos = mujoco_data->xpos + 3 * body_id;
+    mjtNum *quat = mujoco_data->xquat + 4 * body_id;
 
     // Fill in the pose message
     target.pose.pose.position.x = pos[0];
@@ -50,10 +49,7 @@ void MujocoMocap::update(mjModel *mujoco_model, mjData *mujoco_data)
     target.pose.pose.orientation.z = quat[2];
     target.pose.pose.orientation.w = quat[3];
 
-    // Fill in the twist message
-    target.twist.twist.linear.x = vel[0];
-    target.twist.twist.linear.y = vel[1];
-    target.twist.twist.linear.z = vel[2];
+    // TODO: Fill in the twist and acceleration messages
 
     // Publish messages
     auto time = node_->now();
@@ -77,11 +73,13 @@ void MujocoMocap::register_mocap_targets(const mjModel *mujoco_model)
 
   for (int i = 0; i < mujoco_model->nbody; ++i)
   {
-    if (mujoco_model->body_jntnum[i] == 0)  // Floating body
+    if (true)  // FIXME: Select target
     {
+      const char *target_name = mujoco_model->names + mujoco_model->name_bodyadr[i];
       MocapData target;
-      target.name = mujoco_model->names[mujoco_model->name_bodyadr[i]];
-      target.frame_name = target.name + "_frame";
+
+      target.name = target_name;
+      target.frame_name = target.name + "mocap_frame";
 
       // Initialize messages
       target.pose.header.frame_id = target.frame_name;

--- a/mujoco_ros2_control/src/mujoco_mocap.cpp
+++ b/mujoco_ros2_control/src/mujoco_mocap.cpp
@@ -1,0 +1,104 @@
+// Copyright (c) 2025 Akiyoshi UCHIDA
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "mujoco_ros2_control/mujoco_mocap.hpp"
+
+namespace mujoco_ros2_control
+{
+
+MujocoMocap::MujocoMocap(rclcpp::Node::SharedPtr &node) : node_(node) {}
+
+void MujocoMocap::init(mjModel *mujoco_model)
+{
+  // Add user mocaps
+  register_mocap_targets(mujoco_model);
+}
+
+void MujocoMocap::update(mjModel *mujoco_model, mjData *mujoco_data)
+{
+  for (auto &target : mocap_targets_)
+  {
+    // Update pose, twist, and acceleration data in global frame
+    int body_id = mj_name2id(mujoco_model, mjOBJ_BODY, target.name.c_str());
+    mjtNum *pos = mujoco_data->xpos + 3 * mujoco_model->body_jntadr[body_id];
+    mjtNum *quat = mujoco_data->xquat + 4 * mujoco_model->body_jntadr[body_id];
+    mjtNum *vel = mujoco_data->qvel + mujoco_model->nv * mujoco_model->body_jntadr[body_id];
+
+    // Fill in the pose message
+    target.pose.pose.position.x = pos[0];
+    target.pose.pose.position.y = pos[1];
+    target.pose.pose.position.z = pos[2];
+    target.pose.pose.orientation.x = quat[0];
+    target.pose.pose.orientation.y = quat[1];
+    target.pose.pose.orientation.z = quat[2];
+    target.pose.pose.orientation.w = quat[3];
+
+    // Fill in the twist message
+    target.twist.twist.linear.x = vel[0];
+    target.twist.twist.linear.y = vel[1];
+    target.twist.twist.linear.z = vel[2];
+
+    // Publish messages
+    auto time = node_->now();
+    target.pose.header.stamp = time;
+    target.twist.header.stamp = time;
+    target.accel.header.stamp = time;
+
+    target.pose_pub->publish(target.pose);
+    target.twist_pub->publish(target.twist);
+    target.accel_pub->publish(target.accel);
+  }
+}
+
+void MujocoMocap::close() {}
+
+void MujocoMocap::register_mocap_targets(const mjModel *mujoco_model)
+{
+  // CUrrently registering all floating bodies as mocap targets.
+  // TODO: Make it possible to register specific target from the model file ot ros2_control tag.
+  mocap_targets_.resize(0);
+
+  for (int i = 0; i < mujoco_model->nbody; ++i)
+  {
+    if (mujoco_model->body_jntnum[i] == 0)  // Floating body
+    {
+      MocapData target;
+      target.name = mujoco_model->names[mujoco_model->name_bodyadr[i]];
+      target.frame_name = target.name + "_frame";
+
+      // Initialize messages
+      target.pose.header.frame_id = target.frame_name;
+      target.twist.header.frame_id = target.frame_name;
+      target.accel.header.frame_id = target.frame_name;
+
+      // Create publishers
+      target.pose_pub = node_->create_publisher<geometry_msgs::msg::PoseStamped>(
+        target.name + "/pose", rclcpp::QoS(10));
+      target.twist_pub = node_->create_publisher<geometry_msgs::msg::TwistStamped>(
+        target.name + "/twist", rclcpp::QoS(10));
+      target.accel_pub = node_->create_publisher<geometry_msgs::msg::AccelStamped>(
+        target.name + "/accel", rclcpp::QoS(10));
+
+      mocap_targets_.push_back(target);
+    }
+  }
+}
+
+}  // namespace mujoco_ros2_control

--- a/mujoco_ros2_control/src/mujoco_ros2_control_node.cpp
+++ b/mujoco_ros2_control/src/mujoco_ros2_control_node.cpp
@@ -22,6 +22,7 @@
 #include "rclcpp/rclcpp.hpp"
 
 #include "mujoco_ros2_control/mujoco_cameras.hpp"
+#include "mujoco_ros2_control/mujoco_mocap.hpp"
 #include "mujoco_ros2_control/mujoco_rendering.hpp"
 #include "mujoco_ros2_control/mujoco_ros2_control.hpp"
 
@@ -68,6 +69,12 @@ int main(int argc, const char **argv)
   RCLCPP_INFO_STREAM(
     node->get_logger(), "Mujoco ros2 controller has been successfully initialized !");
 
+  // initialize mujoco mocap
+  // TODO: Shoule be separated
+  auto mujoco_mocap = std::make_unique<mujoco_ros2_control::MujocoMocap>(node);
+  mujoco_mocap->init(mujoco_model);
+  RCLCPP_INFO_STREAM(node->get_logger(), "Mujoco mocap has been successfully initialized !");
+
   // initialize mujoco visualization environment for rendering and cameras
   if (!glfwInit())
   {
@@ -97,9 +104,11 @@ int main(int argc, const char **argv)
 
     // Updating cameras at ~6 Hz
     // TODO(eholum): Break control and rendering into separate processes
+    // TODO: Mocap should be handled in a separate thread
     if (simstart - last_cam_update > 1.0 / 6.0)
     {
       cameras->update(mujoco_model, mujoco_data);
+      mujoco_mocap->update(mujoco_model, mujoco_data);
       last_cam_update = simstart;
     }
   }


### PR DESCRIPTION
Hi, I'm a master's student studying space robotics, and I really appreciate this package. It's been incredibly helpful for my work!

I'm currently working on simulating an orbital robot with a floating base using mujoco_ros2_control. In our real-world experiments, we use a motion capture system to obtain the pose and twist of the robot base. To replicate this in simulation, I’d like to publish ground truth data (simulated motion capture) from MuJoCo.

In this PR, I’ve added a basic publisher to mujoco_ros2_control_node.cpp to simulate mocap data of all bodies. However, I’m aware this might not be the best practice, so I’m looking for guidance on a few points:

- What is the best practice for specifying mocap targets in the MJCF or URDF model to register motion capture targets via MujocoMocap::register_mocap_targets? (using some ros2 control tag?) 

- Is it appropriate to include the mocap ground truth publisher inside the mujoco_ros2_control_node, or would a separate node be more suitable?

I’d really appreciate any feedback or suggestions on how to better structure this functionality. Thank you in advance for your support!